### PR TITLE
Basic support for adding colocation, location and order constraints with pcs

### DIFF
--- a/manifests/constraint/base.pp
+++ b/manifests/constraint/base.pp
@@ -1,0 +1,63 @@
+define pacemaker::constraint::base ($constraint_type,
+                                    $first_resource,
+                                    $second_resource=undef,
+                                    $first_action=undef,
+                                    $second_action=undef,
+                                    $location=undef,
+                                    $score=undef,
+                                    $ensure=present) {
+
+  validate_re($constraint_type, ['colocation', 'order', 'location'])
+
+  if($constraint_type == 'order' and ($first_action == undef or $second_action == undef)) {
+    fail("Must provide actions when constraint type is order")
+  }
+
+  if($constraint_type == 'location' and $location == undef) {
+    fail("Must provide location when constraint type is location")
+  }
+
+  if($constraint_type == 'location' and $score == undef) {
+    fail("Must provide score when constraint type is location")
+  }
+
+  if($ensure == absent) {
+    if($constraint_type == 'location') {
+      exec { "Removing location constraint ${name}":
+        command => "/usr/sbin/pcs constraint location remove ${name}",
+        onlyif  => "/usr/sbin/pcs constraint location show --full | grep ${name}",
+        require => Exec["Start Cluster ${corosync::cluster_name}"],
+      }
+    } else {
+      exec { "Removing ${constraint_type} constraint ${name}":
+        command => "/usr/sbin/pcs constraint ${constraint_type} remove ${first_resource} ${second_resource}",
+        onlyif  => "/usr/sbin/pcs constraint ${constraint_type} show | grep ${first_resource} | grep ${second_resource}",
+        require => Exec["Start Cluster ${corosync::cluster_name}"],
+      }
+    }
+  } else {
+    case $constraint_type {
+      'colocation': {
+        exec { "Creating colocation constraint ${name}":
+          command => "/usr/sbin/pcs constraint colocation add ${first_resource} ${second_resource} ${score}",
+          unless  => "/usr/sbin/pcs constraint colocation show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
+          require => [Exec["Start Cluster ${corosync::cluster_name}"],Package["pcs"]],
+        }
+      }
+      'order': {
+        exec { "Creating order constraint ${name}":
+          command => "/usr/sbin/pcs constraint order ${first_action} ${first_resource} then ${second_action} ${second_resource}",
+          unless  => "/usr/sbin/pcs constraint order show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
+          require => [Exec["Start Cluster ${corosync::cluster_name}"],Package["pcs"]],
+        }
+      }
+      'location': {
+        exec { "Creating location constraint ${name}":
+          command => "/usr/sbin/pcs constraint location add ${name} ${first_resource} ${location} ${score}",
+          unless  => "/usr/sbin/pcs constraint location show | grep ${first_resource} > /dev/null 2>&1",
+          require => [Exec["Start Cluster ${corosync::cluster_name}"],Package["pcs"]],
+        }
+      }
+    }
+  }
+}

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -65,3 +65,24 @@ class {'pacemaker::resource::qpid':
       cluster_name => "qpid_cluster",
 }
 
+### Add constraints
+pacemaker::constraint::base { "ip-192.168.122.223_with_fs-mnt":
+  constraint_type => 'colocation',
+  first_resource  => 'ip-192.168.122.223',
+  second_resource => 'fs-mnt',
+}
+
+pacemaker::constraint::base { "ip-192.168.122.223_before_fs-mnt":
+  constraint_type => 'order',
+  first_resource  => 'ip-192.168.122.223',
+  second_resource => 'fs-mnt',
+  first_action    => 'start',
+  second_action   => 'start',
+}
+
+pacemaker::constraint::base { "ip-192.168.122.223_on_192.168.122.3":
+  constraint_type => 'location',
+  first_resource  => 'ip-192.168.122.223',
+  location        => '192.168.122.3',
+  score           => 'INFINITY',
+}


### PR DESCRIPTION
Hi,

I've added support for all three types of constraints supported by pcs (location, colocation and order) using the same basic pattern that is used for resources. Support for some suboptions is still missing, and there are no wrapper classes like with resources, but the base manifest should be usable as is.

Cheers,

  Risto Laurikainen
