### PR TITLE
Add management of the pacemaker service.

### DIFF
--- a/manifests/corosync.pp
+++ b/manifests/corosync.pp
@@ -1,30 +1,26 @@
 class pacemaker::corosync($cluster_name, $cluster_members) inherits pacemaker {
 
     firewall { '001 corosync mcast':
-        proto    => 'udp',
-        dport    => ['5404', '5405'],
-        action   => 'accept',
-    }
-
-    package {["pacemaker", "pcs", "cman"]:
-	ensure  => "installed",
+      proto  => 'udp',
+      dport  => ['5404', '5405'],
+      action => 'accept',
     }
 
     exec {"Set password for hacluster user on $cluster_name":
-        command => "/bin/echo CHANGEME | /usr/bin/passwd --stdin hacluster",
-        creates => "/etc/cluster/cluster.conf",
-        require => [Package["pcs"], Package["pacemaker"]]
+      command => "/bin/echo CHANGEME | /usr/bin/passwd --stdin hacluster",
+      creates => "/etc/cluster/cluster.conf",
+      require => Class["::pacemaker::install"],
     }
-    
+
     exec {"Create Cluster $cluster_name":
-        creates => "/etc/cluster/cluster.conf",
-        command => "/usr/sbin/pcs cluster setup --name $cluster_name $cluster_members",
-        require => [Package["pcs"], Package["cman"]],
+      creates => "/etc/cluster/cluster.conf",
+      command => "/usr/sbin/pcs cluster setup --name $cluster_name $cluster_members",
+      require => Class["::pacemaker::install"],
     }
 
     exec {"Start Cluster $cluster_name":
-        unless => "/usr/sbin/pcs status > /dev/null 2>&1",
-        command => "/usr/sbin/pcs cluster start",
-        require => Exec["Create Cluster $cluster_name"],
+      unless => "/usr/sbin/pcs status > /dev/null 2>&1",
+      command => "/usr/sbin/pcs cluster start",
+      require => Exec["Create Cluster $cluster_name"],
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # == Class: pacemaker
 #
-# base class for pacemaker 
+# base class for pacemaker
 #
 # === Parameters
 #
@@ -32,5 +32,7 @@
 class pacemaker(
   $hacluster_pwd        = $pacemaker::params::hacluster_pwd
 ) inherits pacemaker::params {
-
+  include ::pacemaker::params
+  include ::pacemaker::install
+  include ::pacemaker::service
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,8 @@
+class pacemaker::install (
+  $ensure = present,
+) {
+  include pacemaker::params
+  package { $pacemaker::params::package_list:
+    ensure => $ensure,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,17 @@
 class pacemaker::params {
 
   $hacluster_pwd         = 'CHANGEME'
-
+  case $::osfamily {
+    redhat: {
+      $package_list = ["pacemaker", "pcs", "cman"]
+      $service_name = 'pacemaker'
+    }
+    default: {
+      case $::operatingsystem {
+        default: {
+          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
+        }
+      }
+    }
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,16 @@
+class pacemaker::service (
+  $ensure     = running,
+  $hasstatus  = true,
+  $hasrestart = true,
+  $enable     = true,
+) {
+  include pacemaker::params
+
+  service { $pacemaker::params::service_name:
+    ensure     => $ensure,
+    hasstatus  => $hasstatus,
+    hasrestart => $hasrestart,
+    enable     => $enable,
+    require    => Class['::pacemaker::install'],
+  }
+}


### PR DESCRIPTION
This includes:
- A little extraction of things to params.pp
- Implementation of the parts of the package -> config -> service pattern that
  make sense (since pacemaker writes its own cluster.conf)
- A little formatting cleanup where file was touched anyway
