### PR TITLE
fence_xvm updates

### DIFF
--- a/manifests/stonith/fence_xvm.pp
+++ b/manifests/stonith/fence_xvm.pp
@@ -1,27 +1,39 @@
 # To use this class ensure that fence_virtd is properly configured and running on the hypervisor
 
 class pacemaker::stonith::fence_xvm(
-    $name,
-    $password,
-    $key_file="/etc/cluster/fence_xvm.key",
-    $interval="30s",
-    $ensure=present)
-  inherits pacemaker::corosync {
-    if($ensure == absent) {
-        exec { "Removing stonith::fence_xvm ${name}":
-        command => "/usr/sbin/pcs stonith delete stonith-fence_xvm-${name }",
-        onlyif  => "/usr/sbin/pcs stonith show stonith-fence_xvm-${name} > /dev/null 2>&1",
-        require => Exec["Start Cluster $cluster_name"],
-        }
-    } else {
-        file { "$key_file":
-            content => "$password",
-        }
-
-        exec { "Creating stonith::fence_xvm ${name}":
-        command => "/usr/sbin/pcs stonith create stonith-fence_xvm-${name} fence_xvm op monitor interval=${interval}",
-        unless  => "/usr/sbin/pcs stonith show stonith-fence_xvm-${name} > /dev/null 2>&1",
-        require => [Exec["Start Cluster $cluster_name"],Package["pcs"]]
-        }
+  $name,
+  $manage_key_file=false,
+  $key_file="/etc/cluster/fence_xvm.key",
+  $key_file_password="123456",
+  $interval="30s",
+  $ensure=present,
+  $port=undef,       # the name of the vm
+  $pcmk_host=undef,  # the hostname or IP that pacemaker uses
+  ) {
+  if($ensure == absent) {
+    exec { "Removing stonith::fence_xvm ${name}":
+      command => "/usr/sbin/pcs stonith delete fence_xvm-${name }",
+      onlyif  => "/usr/sbin/pcs stonith show fence_xvm-${name} > /dev/null 2>&1",
+      require => Class['pacemaker::corosync'],
     }
+  } else {
+    $port_chunk = $port ? {
+      ''      => '',
+      default => "port=${port}",
+    }
+    $pcmk_host_list_chunk = $pcmk_host ? {
+      ''      => '',
+      default => "pcmk_host_list=${pcmk_host}",
+    }
+    if $manage_key_file {
+      file { "$key_file":
+        content => "$key_file_password",
+      }
+    }
+    exec { "Creating stonith::fence_xvm ${name}":
+      command => "/usr/sbin/pcs stonith create fence_xvm-${name} fence_xvm ${port_chunk} ${pcmk_host_list_chunk} op monitor interval=${interval}",
+      unless  => "/usr/sbin/pcs stonith show fence_xvm-${name}  > /dev/null 2>&1",
+      require => Class['pacemaker::corosync'],
+    }
+  }
 }


### PR DESCRIPTION
Sample usage:

  class {'pacemaker::stonith::fence_xvm':
    name              => "$::hostname",
    manage_key_file   => true,
    key_file_password => '123456788888',
  }

  class {'pacemaker::stonith::fence_xvm':
    name             => "$::hostname",
    manage_key_file  => false,
    port             => "$::hostname",    # the name of the vm
    pcmk_host        => $clu_ip_address,  # the hostname or IP that pacemaker uses
  }
