### PR TITLE
no cman for el7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,11 @@ class pacemaker::params {
   $hacluster_pwd         = 'CHANGEME'
   case $::osfamily {
     redhat: {
-      $package_list = ["pacemaker", "pcs", "cman"]
+      if $::operatingsystemrelease =~ /^6\..*$/ {      
+        $package_list = ["pacemaker", "pcs", "cman"]
+      } else {
+        $package_list = ["pacemaker", "pcs"]
+      }
       $service_name = 'pacemaker'
     }
     default: {


### PR DESCRIPTION
I _think_ cman is gone from el7, but need outside confirmation before this gets merged.
