### PR TITLE
Add pacemaker ocf resources support.

### DIFF
--- a/manifests/resource/ocf.pp
+++ b/manifests/resource/ocf.pp
@@ -1,0 +1,19 @@
+define pacemaker::resource::ocf($group='',
+                                $clone=false,
+                                $interval='30s',
+                                $monitor_params=undef,
+                                $ensure='present',
+                                $options='',
+                                $resource_name='') {
+
+  pcmk_resource { "${name}":
+    ensure          => $ensure,
+    resource_type   => "ocf:${resource_name}",
+    resource_params => $options,
+    group           => $group,
+    clone           => $clone,
+    interval        => $interval,
+    monitor_params  => $monitor_params,
+  }
+
+}


### PR DESCRIPTION
OCF RA's are shell scripts that provide resources in a different standard to LSB or systemd, 
those are used in neutron-netns-cleanup and neutron-ovs-cleanup for rhos5+rhel7/6

https://github.com/fabbione/rhos-ha-deploy/blob/master/rhos5-rhel7/mrgcloud-setup/RHOS-RHEL-HA-how-to-mrgcloud-rhos5-on-rhel7-neutron-n-latest.txt#L100

Best regards,
Miguel Ángel
