### PR TITLE
Fix route resource ID

### DIFF
--- a/manifests/resource/route.pp
+++ b/manifests/resource/route.pp
@@ -28,7 +28,7 @@ define pacemaker::resource::route($src='',
       default => " gateway=$gateway"
   }
 
-  pcmk_resource { "route-${src}-${dest}-${gateway}-${group}":
+  pcmk_resource { "route-${name}-${group}":
     ensure          => $ensure,
     resource_type   => 'Route',
     resource_params => "${dest_option} ${src_option} ${nic_option} ${gw_option}",


### PR DESCRIPTION
The destination wants an ip/netmask pair, but pacemaker won't accept that in the resource name.

This uses route-{puppet name}-{group} instead, which should be fine since the puppet name is unique anyway.
