### PR TITLE
Proper password & timeout settings

### DIFF
--- a/manifests/corosync.pp
+++ b/manifests/corosync.pp
@@ -59,10 +59,10 @@ class pacemaker::corosync(
     }
     ->
     exec {"auth-successful-across-all-nodes":
-      command => "/usr/sbin/pcs cluster auth $cluster_members -u hacluster -p ${::pacemaker::hacluster_pwd} --force",
-      timeout   => 3600,
-      tries     => 360,
-      try_sleep => 10,
+      command   => "/usr/sbin/pcs cluster auth $cluster_members -u hacluster -p ${::pacemaker::hacluster_pwd} --force",
+      timeout   => $settle_timeout,
+      tries     => $settle_tries,
+      try_sleep => $settle_try_sleep,
     }
     ->
     Exec["wait-for-settle"]


### PR DESCRIPTION
This pull request aims to provide two changes
- Change 1 : Currently, the `pacemaker::corosync` `$hacluster_pwd` needs to be set manually in the `params.pp` file, there is no way to specify it via the module parameters, the first commit changes that.
- Change 2 : Sometime, one might want to timeout early, or earlier, by parametrizing the `auth-successful-across-all-nodes` timeout settings it is made available.
