### PR TITLE
Remove inheritance from pacemaker::stonith of pacemaker::corosync

### DIFF
--- a/manifests/stonith.pp
+++ b/manifests/stonith.pp
@@ -1,15 +1,19 @@
-class pacemaker::stonith ($disable=true) inherits pacemaker::corosync {
+class pacemaker::stonith ($disable=true) {
   if $disable == true {
     exec {"Disable STONITH":
         command => "/usr/sbin/pcs property set stonith-enabled=false",
         unless => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
-        require => Exec["wait-for-settle"],
+        require => [ Exec["wait-for-settle"],
+                     Class['::pacemaker::corosync']
+                   ],
     }
   } else {
     exec {"Enable STONITH":
         command => "/usr/sbin/pcs property set stonith-enabled=true",
         onlyif => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
-        require => Exec["wait-for-settle"],
+        require => [ Exec["wait-for-settle"],
+                     Class['::pacemaker::corosync']
+                   ],
     }
   }
 }


### PR DESCRIPTION
When using the pacemaker module together with an ENC, (Satellite 6)
we ran into the problem that we want to include both the pacemaker::stonith
and the pacemaker::corosync classes into our manifest in order to assign parameters
to both. Here we ran into a problem since the pacemaker::corosync class ended up redefined.
We have here removed the inheritance and instead put a require in the pacemaker::stonith class
