### PR TITLE
Cleanup up code according to puppet-lint.  Added a few things.

### DIFF
--- a/manifests/constraint/base.pp
+++ b/manifests/constraint/base.pp
@@ -1,3 +1,17 @@
+# == Define: pacemaker::constraint::base
+#
+# Description: <TODO>
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#
+# === Copyright
+#
+#
 define pacemaker::constraint::base (
   $constraint_type,
   $constraint_params = undef,
@@ -15,37 +29,37 @@ define pacemaker::constraint::base (
   validate_re($constraint_type, ['colocation', 'order', 'location'])
 
   if($constraint_type == 'order' and ($first_action == undef or $second_action == undef)) {
-    fail("Must provide actions when constraint type is order")
+    fail('Must provide actions when constraint type is order')
   }
 
   if($constraint_type == 'location' and $location == undef) {
-    fail("Must provide location when constraint type is location")
+    fail('Must provide location when constraint type is location')
   }
 
   if($constraint_type == 'location' and $score == undef) {
-    fail("Must provide score when constraint type is location")
+    fail('Must provide score when constraint type is location')
   }
 
   if $constraint_params != undef {
-    $_constraint_params = "${constraint_params}"
+    $_constraint_params = $constraint_params
   } else {
-    $_constraint_params = ""
+    $_constraint_params = ''
   }
 
   if($ensure == absent) {
     if($constraint_type == 'location') {
       exec { "Removing location constraint ${name}":
-        command => "/usr/sbin/pcs constraint location remove ${name}",
-        onlyif  => "/usr/sbin/pcs constraint location show --full | grep ${name}",
-        require => Exec["wait-for-settle"],
+        command   => "/usr/sbin/pcs constraint location remove ${name}",
+        onlyif    => "/usr/sbin/pcs constraint location show --full | grep ${name}",
+        require   => Exec['wait-for-settle'],
         tries     => $tries,
         try_sleep => $try_sleep,
       }
     } else {
       exec { "Removing ${constraint_type} constraint ${name}":
-        command => "/usr/sbin/pcs constraint ${constraint_type} remove ${first_resource} ${second_resource}",
-        onlyif  => "/usr/sbin/pcs constraint ${constraint_type} show | grep ${first_resource} | grep ${second_resource}",
-        require => Exec["wait-for-settle"],
+        command   => "/usr/sbin/pcs constraint ${constraint_type} remove ${first_resource} ${second_resource}",
+        onlyif    => "/usr/sbin/pcs constraint ${constraint_type} show | grep ${first_resource} | grep ${second_resource}",
+        require   => Exec['wait-for-settle'],
         tries     => $tries,
         try_sleep => $try_sleep,
       }
@@ -53,33 +67,45 @@ define pacemaker::constraint::base (
   } else {
     case $constraint_type {
       'colocation': {
-        fail("Deprecated use pacemaker::constraint::colocation")
+        fail('Deprecated use pacemaker::constraint::colocation')
         exec { "Creating colocation constraint ${name}":
-          command => "/usr/sbin/pcs constraint colocation add ${first_resource} ${second_resource} ${score}",
-          unless  => "/usr/sbin/pcs constraint colocation show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
-          require => [Exec["wait-for-settle"],Package["pcs"]],
+          command   => "/usr/sbin/pcs constraint colocation add ${first_resource} ${second_resource} ${score}",
+          unless    => "/usr/sbin/pcs constraint colocation show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
           tries     => $tries,
           try_sleep => $try_sleep,
+          require   => [
+                        Exec['wait-for-settle'],
+                        Package['pcs']
+                      ],
         }
       }
       'order': {
         exec { "Creating order constraint ${name}":
-          command => "/usr/sbin/pcs constraint order ${first_action} ${first_resource} then ${second_action} ${second_resource} ${_constraint_params}",
-          unless  => "/usr/sbin/pcs constraint order show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
-          require => [Exec["wait-for-settle"],Package["pcs"]],
+          command   => "/usr/sbin/pcs constraint order ${first_action} ${first_resource} then ${second_action} ${second_resource} ${_constraint_params}",
+          unless    => "/usr/sbin/pcs constraint order show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
           tries     => $tries,
           try_sleep => $try_sleep,
+          require   => [
+                        Exec['wait-for-settle'],
+                        Package['pcs']
+                      ],
         }
       }
       'location': {
-        fail("Deprecated use pacemaker::constraint::location")
+        fail('Deprecated use pacemaker::constraint::location')
         exec { "Creating location constraint ${name}":
-          command => "/usr/sbin/pcs constraint location add ${name} ${first_resource} ${location} ${score}",
-          unless  => "/usr/sbin/pcs constraint location show | grep ${first_resource} > /dev/null 2>&1",
-          require => [Exec["wait-for-settle"],Package["pcs"]],
+          command   => "/usr/sbin/pcs constraint location add ${name} ${first_resource} ${location} ${score}",
+          unless    => "/usr/sbin/pcs constraint location show | grep ${first_resource} > /dev/null 2>&1",
           tries     => $tries,
           try_sleep => $try_sleep,
+          require   => [
+                        Exec['wait-for-settle'],
+                        Package['pcs']
+                      ],
         }
+      }
+      default: {
+        fail('Unknown constaint type')
       }
     }
   }

--- a/manifests/constraint/colocation.pp
+++ b/manifests/constraint/colocation.pp
@@ -1,14 +1,30 @@
-define pacemaker::constraint::colocation ($source,
-                                          $target,
-                                          $score,
-                                          $ensure=present) {
-    pcmk_constraint {"colo-$source-$target":
-       constraint_type => colocation,
-       resource        => $source,
-       location        => $target,
-       score           => $score,
-       ensure          => $ensure,
-       require => Exec["wait-for-settle"],
-   }
+# == Define: pacemaker::constraint::colocation
+#
+# Description:
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#
+# === Copyright
+#
+#
+define pacemaker::constraint::colocation (
+$source,
+$target,
+$score,
+$ensure = present
+) {
+  pcmk_constraint {"colo-${source}-${target}":
+    ensure          => $ensure,
+    constraint_type => colocation,
+    resource        => $source,
+    location        => $target,
+    score           => $score,
+    require         => Exec['wait-for-settle'],
+  }
 }
 

--- a/manifests/constraint/location.pp
+++ b/manifests/constraint/location.pp
@@ -1,14 +1,29 @@
-define pacemaker::constraint::location ($resource,
-                                        $location,
-                                        $score,
-                                        $ensure='present') {
-    pcmk_constraint {"loc-$resource-$location":
-       constraint_type => location,
-       resource        => $resource,
-       location        => $location,
-       score           => $score,
-       ensure          => $ensure,
-       require => Exec["wait-for-settle"],
-   }
+# == Define: pacemaker::constraint::location
+#
+# Description:
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#
+# === Copyright
+#
+#
+define pacemaker::constraint::location (
+$resource,
+$location,
+$score,
+$ensure='present',
+) {
+  pcmk_constraint {"loc-${resource}-${location}":
+    ensure          => $ensure,
+    constraint_type => location,
+    resource        => $resource,
+    location        => $location,
+    score           => $score,
+    require         => Exec['wait-for-settle'],
+  }
 }
- 

--- a/manifests/corosync.pp
+++ b/manifests/corosync.pp
@@ -27,6 +27,11 @@ class pacemaker::corosync(
   $settle_timeout   = '3600',
   $settle_tries     = '360',
   $settle_try_sleep = '10',
+  $pcs_token        = '1000',
+  $pcs_join         = '50',
+  $pcs_consensus    = '1200',
+  $pcs_miss_count   = '5',
+  $pcs_fail_recv    = '2500',
 ) inherits pacemaker {
   include ::pacemaker::params
 
@@ -48,57 +53,57 @@ class pacemaker::corosync(
     }
     Service['pcsd'] ->
     # we have more fragile when-to-start pacemaker conditions with pcsd
-    exec {"enable-not-start-$cluster_name":
-      command => "/usr/sbin/pcs cluster enable"
+    exec {"enable-not-start-${cluster_name}":
+      command => '/usr/sbin/pcs cluster enable'
     }
     ->
-    exec {"Set password for hacluster user on $cluster_name":
+    exec {"Set password for hacluster user on ${cluster_name}":
       command => "/bin/echo ${::pacemaker::hacluster_pwd} | /usr/bin/passwd --stdin hacluster",
-      creates => "/etc/cluster/cluster.conf",
-      require => Class["::pacemaker::install"],
+      creates => '/etc/cluster/cluster.conf',
+      require => Class['::pacemaker::install'],
     }
     ->
-    exec {"auth-successful-across-all-nodes":
-      command   => "/usr/sbin/pcs cluster auth $cluster_members -u hacluster -p ${::pacemaker::hacluster_pwd} --force",
+    exec {'auth-successful-across-all-nodes':
+      command   => "/usr/sbin/pcs cluster auth ${cluster_members} -u hacluster -p ${::pacemaker::hacluster_pwd} --force",
       timeout   => $settle_timeout,
       tries     => $settle_tries,
       try_sleep => $settle_try_sleep,
     }
     ->
-    Exec["wait-for-settle"]
+    Exec['wait-for-settle']
   }
 
   if $setup_cluster {
-    exec {"Create Cluster $cluster_name":
-      creates => "/etc/cluster/cluster.conf",
-      command => "/usr/sbin/pcs cluster setup --name $cluster_name $cluster_members",
-      unless => "/usr/bin/test -f /etc/corosync/corosync.conf",
-      require => Class["::pacemaker::install"],
+    exec {"Create Cluster ${cluster_name}":
+      creates => '/etc/cluster/cluster.conf',
+      command => "/usr/sbin/pcs cluster setup --name ${cluster_name} ${cluster_members} --token=${pcs_token} --join=${pcs_join} --miss_count_const=${pcs_miss_count} --consensus=${pcs_consensus} --fail_recv_const=${pcs_fail_recv}",
+      unless  => '/usr/bin/test -f /etc/corosync/corosync.conf',
+      require => Class['::pacemaker::install'],
     }
     ->
-    exec {"Start Cluster $cluster_name":
-      unless => "/usr/sbin/pcs status >/dev/null 2>&1",
-      command => "/usr/sbin/pcs cluster start --all",
-      require => Exec["Create Cluster $cluster_name"],
+    exec {"Start Cluster ${cluster_name}":
+      unless  => '/usr/sbin/pcs status >/dev/null 2>&1',
+      command => '/usr/sbin/pcs cluster start --all',
+      require => Exec["Create Cluster ${cluster_name}"],
     }
     if $pcsd_mode {
-      Exec["auth-successful-across-all-nodes"] ->
-        Exec["Create Cluster $cluster_name"]
+      Exec['auth-successful-across-all-nodes'] ->
+        Exec["Create Cluster ${cluster_name}"]
     }
-    Exec["Start Cluster $cluster_name"] ->
-      Exec["wait-for-settle"]
+    Exec["Start Cluster ${cluster_name}"] ->
+      Exec['wait-for-settle']
   }
 
-  exec {"wait-for-settle":
+  exec { 'wait-for-settle':
     timeout   => $settle_timeout,
     tries     => $settle_tries,
     try_sleep => $settle_try_sleep,
     command   => "/usr/sbin/pcs status | grep -q 'partition with quorum' > /dev/null 2>&1",
     unless    => "/usr/sbin/pcs status | grep -q 'partition with quorum' > /dev/null 2>&1",
-    notify    => Notify["pacemaker settled"],
+    notify    => Notify['pacemaker settled'],
   }
 
-  notify {"pacemaker settled":
-    message => "Pacemaker has reported quorum achieved",
+  notify {'pacemaker settled':
+    message => 'Pacemaker has reported quorum achieved',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,9 +30,7 @@
 #
 
 class pacemaker(
-  $hacluster_pwd        = $pacemaker::params::hacluster_pwd
 ) inherits pacemaker::params {
-  include ::pacemaker::params
   include ::pacemaker::install
   include ::pacemaker::service
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,28 @@
+# == Class: pacemaker::install
+#
+# Description: Install the pacemaker packages
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#  include ::pacemaker::install
+#
+# === Copyright
+#
+#
 class pacemaker::install (
   $ensure = present,
 ) {
+
+  if $ensure != present and $ensure != absent {
+      fail('The only valid values for the ensure parameter are present or absent')
+  }
+
   include pacemaker::params
+
   package { $pacemaker::params::package_list:
     ensure => $ensure,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,26 +1,39 @@
+# == Class: pacemaker::params
+#
+# Description: <TODO>
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#  include ::pacemaker::params
+#
+# === Copyright
+#
+#
+#
 class pacemaker::params {
 
   $hacluster_pwd         = 'CHANGEME'
+
   case $::osfamily {
     redhat: {
       if $::operatingsystemrelease =~ /^6\..*$/ {
-        $package_list = ["pacemaker","pcs","fence-agents","cman"]
+        $package_list = ['pacemaker', 'pcs', 'fence-agents', 'cman']
         # TODO in el6.6, $pcsd_mode should be true
         $pcsd_mode = false
         $services_manager = 'lsb'
       } else {
-        $package_list = ["pacemaker","pcs","fence-agents-all"]
+        $package_list = ['pacemaker', 'pcs', 'fence-agents-all']
         $pcsd_mode = true
         $services_manager = 'systemd'
       }
       $service_name = 'pacemaker'
     }
     default: {
-      case $::operatingsystem {
-        default: {
-          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
-        }
-      }
+      fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,14 +21,18 @@ class pacemaker::params {
   case $::osfamily {
     redhat: {
       if $::operatingsystemrelease =~ /^6\..*$/ {
-        $package_list = ['pacemaker', 'pcs', 'fence-agents', 'cman']
+        $package_list     = ['pacemaker', 'pcs', 'fence-agents', 'cman']
         # TODO in el6.6, $pcsd_mode should be true
-        $pcsd_mode = false
-        $services_manager = 'lsb'
+        $pcsd_mode         = false
+        $services_manager  = 'lsb'
+        $config_file       = '/etc/cluster/cluster.conf'
+        $enabled_check_cmd = '/usr/bin/false'
       } else {
-        $package_list = ['pacemaker', 'pcs', 'fence-agents-all']
-        $pcsd_mode = true
+        $package_list     = ['pacemaker', 'pcs', 'fence-agents-all']
+        $pcsd_mode        = true
         $services_manager = 'systemd'
+        $config_file      = '/etc/corosync/corosync.conf'
+        $enabled_check_cmd = '/usr/bin/systemctl is-enabled corosync && /usr/bin/systemctl is-enabled pacemaker'
       }
       $service_name = 'pacemaker'
     }

--- a/manifests/resource/route.pp
+++ b/manifests/resource/route.pp
@@ -1,3 +1,17 @@
+# == Define: pacemaker::resource::systemd
+#
+# Description:
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#  include ::pacemaker::resource::systemd
+#
+# === Copyright
+#
 define pacemaker::resource::route(
   $ensure             = 'present',
   $src                = '',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,3 +1,19 @@
+# == Class: pacemaker::service
+#
+# Description: Pacemaker service file
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#  include ::pacemaker::service
+#
+# === Copyright
+#
+#
+#
 class pacemaker::service (
   $ensure     = running,
   $hasstatus  = true,

--- a/manifests/stonith.pp
+++ b/manifests/stonith.pp
@@ -1,19 +1,39 @@
-class pacemaker::stonith ($disable=true) {
+# == Class: pacemaker::stonith
+#
+# Description: Enable or Disable stonith in the cluster
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+#  include ::pacemaker::stonith
+#
+# === Copyright
+#
+#
+#
+class pacemaker::stonith (
+$disable = true
+) {
   if $disable == true {
-    exec {"Disable STONITH":
-        command => "/usr/sbin/pcs property set stonith-enabled=false",
-        unless => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
-        require => [ Exec["wait-for-settle"],
-                     Class['::pacemaker::corosync']
-                   ],
+    exec {'Disable STONITH':
+        command => '/usr/sbin/pcs property set stonith-enabled=false',
+        unless  => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
+        require => [
+                    Exec['wait-for-settle'],
+                    Class['::pacemaker::corosync']
+                    ],
     }
   } else {
-    exec {"Enable STONITH":
-        command => "/usr/sbin/pcs property set stonith-enabled=true",
-        onlyif => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
-        require => [ Exec["wait-for-settle"],
-                     Class['::pacemaker::corosync']
-                   ],
+    exec {'Enable STONITH':
+        command => '/usr/sbin/pcs property set stonith-enabled=true',
+        onlyif  => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
+        require => [
+                    Exec['wait-for-settle'],
+                    Class['::pacemaker::corosync']
+                    ],
     }
   }
 }


### PR DESCRIPTION
Here is some cleanup I've done to this puppet module.  Things I have done:

* did a lot of cleanup work according to puppet-lint.
* changed " to ' in a lot of cases.
* I did not change the auto generated puppet code.
* I added document headers (empty for now).  Puppetlint requirement.
* I added some more options class pacemaker::corosync.  I needed to tweak some of the settings.
* I added some better exec checks in pacemaker::corosync.  I wasn't able to get them all, but i knocked out a lot of things that were re-running on puppet runs.
* I added some config files to check for with the execs.  They were using cman cluster.conf files, which do not exist in rhel 7.
* I removed some unnecessary includes of params in  pacemaker::corosync.  It is being inherited, so it shouldn't need to be included again.