### PR TITLE
Allow one to specify some corosync parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Installs Pacemaker and corosync and creates a cluster
 
 The pacemaker::corosync resource must be executed on each node
 
+If one wants to set non default settings for corosync the `cluster_setup_extras` variable can be used
+
+    class {"pacemaker::corosync":
+        cluster_name => "cluster_name",
+        cluster_members => "clu-host-1 clu-host-2 clu-host-3",
+        cluster_setup_extras => {'--totem' => '10000', '--ipv6' => ''},
+    }
+
 ### Disable stonith
     class {"pacemaker::stonith":
         disable => true,

--- a/manifests/corosync.pp
+++ b/manifests/corosync.pp
@@ -20,16 +20,20 @@
 #   Number of tries for settle.
 # [*settle_try_sleep*]
 #   Time to sleep after each seetle try.
+# [*cluster_setup_extras*]
+#   Hash additional configuration when pcs cluster setup is run
+#   Example : {'--token' => '10000', '--ipv6' => '', '--join' => '100' }
 
 class pacemaker::corosync(
   $cluster_members,
-  $cluster_members_rrp = undef,
-  $cluster_name        = 'clustername',
-  $setup_cluster       = true,
-  $manage_fw           = true,
-  $settle_timeout      = '3600',
-  $settle_tries        = '360',
-  $settle_try_sleep    = '10',
+  $cluster_members_rrp  = undef,
+  $cluster_name         = 'clustername',
+  $setup_cluster        = true,
+  $manage_fw            = true,
+  $settle_timeout       = '3600',
+  $settle_tries         = '360',
+  $settle_try_sleep     = '10',
+  $cluster_setup_extras = {},
 ) inherits pacemaker {
   include ::pacemaker::params
 
@@ -79,9 +83,11 @@ class pacemaker::corosync(
       $cluster_members_rrp_real = $cluster_members_rrp
     }
 
+    $cluster_setup_extras_real = inline_template('<%= @cluster_setup_extras.flatten.join(" ") %>')
+
     exec {"Create Cluster $cluster_name":
       creates => "/etc/cluster/cluster.conf",
-      command => "/usr/sbin/pcs cluster setup --name $cluster_name $cluster_members_rrp_real",
+      command => "/usr/sbin/pcs cluster setup --name $cluster_name $cluster_members_rrp_real $cluster_setup_extras_real",
       unless => "/usr/bin/test -f /etc/corosync/corosync.conf",
       require => Class["::pacemaker::install"],
     }


### PR DESCRIPTION
Currently only the default value for corosync are available. A user can
not set specific values related to corosync due to the fact that the
command run to create the cluster is `pcs cluster setup --start` with no
possible parameters.

This commit aims to allow one to specify all the corosync parameters
available via the `pcs cluster setup --start` command.

An example would be the following

```
 class { '::pacemaker::corosync':
    cluster_members => 'node01.example.com node02.example.com
node03.example.com',
    setup_cluster   => true,
    cluster_setup_extras => {'--token' => '10000', '--join' => '100'},
  }
```

This would result in `pcs cluster corosync` outputing the following:
Note: totem and join values.

```
[root@localhost ~]# pcs cluster corosync
totem {
version: 2
secauth: off
cluster_name: clustername
transport: udpu
token: 10000
join: 100
}
nodelist {
  node {
        ring0_addr: node01.example.com
        nodeid: 1
       }
  node {
        ring0_addr: node02.example.com
        nodeid: 2
       }
  node {
        ring0_addr: node03.example.com
        nodeid: 3
       }
}
quorum {
provider: corosync_votequorum
}
logging {
to_syslog: yes
}
```