### PR TITLE
Support setting pacemaker resource defaults

### DIFF
--- a/lib/puppet/provider/pcmk_resource_default/pcs.rb
+++ b/lib/puppet/provider/pcmk_resource_default/pcs.rb
@@ -1,0 +1,54 @@
+# Currently the implementation is somewhat naive (will not work great
+# with ensure => absent, unless the correct current value is also
+# specified). For more proper handling, prefetching should be
+# implemented and `value` should be switched from a param to a
+# property. This should be possible to do without breaking the
+# interface of the resource type.
+Puppet::Type.type(:pcmk_resource_default).provide(:pcs) do
+  desc 'Manages default values for pacemaker resource options via pcs'
+
+  def create
+    name = @resource[:name]
+    value = @resource[:value]
+
+    cmd = "resource defaults #{name}='#{value}'"
+
+    pcs(cmd)
+  end
+
+  def destroy
+    name = @resource[:name]
+
+    cmd = 'resource defaults #{name}='
+    pcs(cmd)
+  end
+
+  def exists?
+    name = @resource[:name]
+    value = @resource[:value]
+
+    cmd = 'resource defaults'
+    status, _ = pcs(cmd,
+                    :grep => "^#{name}: #{value}$",
+                    :allow_failure => true)
+    status == 0
+  end
+
+  def pcs(cmd, options={})
+    full_cmd = "pcs #{cmd}"
+
+    if options[:grep]
+      full_cmd += " | grep '#{options[:grep]}'"
+    end
+
+    Puppet.debug("Running #{full_cmd}")
+    output = `#{full_cmd}`
+    status = $?.exitstatus
+
+    if status != 0 && !options[:allow_failure]
+      raise Puppet::Error("#{full_cmd} returned #{status}, output: #{output}")
+    end
+
+    [status, output]
+  end
+end

--- a/lib/puppet/type/pcmk_resource_default.rb
+++ b/lib/puppet/type/pcmk_resource_default.rb
@@ -1,0 +1,16 @@
+require 'puppet/parameter/boolean'
+
+Puppet::Type.newtype(:pcmk_resource_default) do
+  @doc = "A default value for pacemaker resource options"
+
+  ensurable
+
+  newparam(:name) do
+    desc "A unique name of the option"
+  end
+
+  newparam(:value) do
+    desc "A default value for the option"
+  end
+
+end

--- a/manifests/resource_defaults.pp
+++ b/manifests/resource_defaults.pp
@@ -1,0 +1,12 @@
+class pacemaker::resource_defaults(
+  $defaults,
+  $ensure = 'present',
+) {
+  create_resources(
+    "pcmk_resource_default",
+    $defaults,
+    {
+      ensure => $ensure,
+    }
+  )
+}


### PR DESCRIPTION
This patch adds initial support for pacemaker resource
defaults. Similarly as other pacemaker resource types in this module, it
doesn't yet prefetch already created resources.

The resource default can either be created directly via
pcmk_resource_default type, or in bulk via pacemaker::resource_defaults
class.