### PR TITLE
Zmw/adding master slave constraint option check

### DIFF
--- a/lib/puppet/provider/pcmk_constraint/default.rb
+++ b/lib/puppet/provider/pcmk_constraint/default.rb
@@ -7,7 +7,11 @@ Puppet::Type.type(:pcmk_constraint).provide(:default) do
         when :location
             cmd = 'constraint location add ' + @resource[:name] + ' '  + @resource[:resource] + ' ' + @resource[:location] + ' ' + @resource[:score]
         when :colocation
-            cmd = 'constraint colocation add ' + @resource[:resource] + ' with ' + @resource[:location] + ' ' + @resource[:score]
+            if @resource[:master_slave]
+                cmd = 'constraint colocation add ' + @resource[:resource] + ' with master ' + @resource[:location] + ' ' + @resource[:score]
+            else 
+                cmd = 'constraint colocation add ' + @resource[:resource] + ' with ' + @resource[:location] + ' ' + @resource[:score]
+            end
         else
             fail(String(@resource[:constraint_type]) + ' is an invalid location type')
         end
@@ -37,7 +41,11 @@ Puppet::Type.type(:pcmk_constraint).provide(:default) do
             when :location
                 return true if line.include? @resource[:name]
             when :colocation
-                return true if line.include? @resource[:resource] + ' with ' + @resource[:location]
+                if @resource[:master_slave]
+                  return true if line.include? @resource[:resource] + ' with ' + @resource[:location] and line.include? "with-rsc-role:Master" 
+                else
+                  return true if line.include? @resource[:resource] + ' with ' + @resource[:location] 
+                end
             end
         end
         # return false if constraint not found

--- a/lib/puppet/type/pcmk_constraint.rb
+++ b/lib/puppet/type/pcmk_constraint.rb
@@ -22,5 +22,10 @@ Puppet::Type.newtype(:pcmk_constraint) do
     newparam(:score) do
         desc "Score"
     end
+    newparam(:master_slave) do
+        desc "Enable master/slave support with multistage"
+        newvalues(:true)
+        newvalues(:false)
+    end
 
 end

--- a/manifests/constraint/colocation.pp
+++ b/manifests/constraint/colocation.pp
@@ -1,12 +1,14 @@
 define pacemaker::constraint::colocation ($source,
                                           $target,
                                           $score,
+                                          $master_slave=false,
                                           $ensure=present) {
     pcmk_constraint {"colo-$source-$target":
        constraint_type => colocation,
        resource        => $source,
        location        => $target,
        score           => $score,
+       master_slave    => $master_slave,
        ensure          => $ensure,
        require => Exec["wait-for-settle"],
    }


### PR DESCRIPTION
Hi!  We are using the multi-state master functionality supplied in pcmk_resource, however when creating constraints that require resources to follow Master role, the exist? function will fail.

We need to be able to pass the constraint provider a boolean to add "with master" 

and then verify that with-rsc-role:Master is contained in subsequent constraint if 'master_slave' true.