### PR TITLE
Ability to set authkey for pacemaker-remote.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class pacemaker::params {
         $pcsd_mode = false
         $services_manager = 'lsb'
       } else {
-        $package_list = ["pacemaker","pcs","fence-agents-all"]
+        $package_list = ["pacemaker","pcs","fence-agents-all","pacemaker-libs"]
         $pcsd_mode = true
         $services_manager = 'systemd'
       }


### PR DESCRIPTION
Setting $remote_authkey will result in the file /etc/pacemaker/authkey
being created with the contents of $remote_authkey.

Also add pacemaker-libs to the list installed pacakges, which includes
the hacluster user and haclient group which own /etc/pacemaker and
/etc/pacemaker/authkey.

See also: http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Remote/_setup_pacemaker_remote.html

It is presumed we are configuring the HOST system here, it is up to
the user to configure the GUEST.