### PR TITLE
Fixes pacemaker::stonith::fence_rhevm defined type

### DIFF
--- a/manifests/stonith/fence_rhevm.pp
+++ b/manifests/stonith/fence_rhevm.pp
@@ -130,20 +130,12 @@ define pacemaker::stonith::fence_rhevm (
       require => Class["pacemaker::corosync"],
     }
   } else {
-    package {
-      "fence-agents-rhevm": ensure => installed,
-    } ->
     exec { "Create stonith-fence_rhevm-${safe_title}":
       command => "/usr/sbin/pcs stonith create stonith-fence_rhevm-${safe_title} fence_rhevm pcmk_host_list=\"${pcmk_host_value_chunk}\" ${ipaddr_chunk} ${login_chunk} ${passwd_chunk} ${ssl_chunk} ${notls_chunk} ${port_chunk} ${ipport_chunk} ${inet4_only_chunk} ${inet6_only_chunk} ${passwd_script_chunk} ${ssl_secure_chunk} ${ssl_insecure_chunk} ${verbose_chunk} ${debug_chunk} ${separator_chunk} ${power_timeout_chunk} ${shell_timeout_chunk} ${login_timeout_chunk} ${power_wait_chunk} ${delay_chunk} ${retry_on_chunk}  op monitor interval=${interval}",
       unless => "/usr/sbin/pcs stonith show stonith-fence_rhevm-${safe_title} > /dev/null 2>&1",
       tries => $tries,
       try_sleep => $try_sleep,
       require => Class["pacemaker::corosync"],
-    } ->
-    exec { "Add non-local constraint for stonith-fence_rhevm-${safe_title}":
-      command => "/usr/sbin/pcs constraint location stonith-fence_rhevm-${safe_title} avoids ${pcmk_host_value_chunk}",
-      tries => $tries,
-      try_sleep => $try_sleep,
     }
   }
 }


### PR DESCRIPTION
allows multiple uses of the defined type (declaring package dependency only once)