### PR TITLE
The colons in IPv6 addresses causing title issues

### DIFF
--- a/manifests/resource/ip.pp
+++ b/manifests/resource/ip.pp
@@ -44,7 +44,10 @@ define pacemaker::resource::ip(
       default => " nic=${nic}"
   }
 
-  pcmk_resource { "ip-${ip_address}":
+  # pcs dislikes colons from IPv6 addresses. Replacing them with dots.
+  $resource_name = regsubst($ip_address, '(:)', '.', 'G')
+
+  pcmk_resource { "ip-${resource_name}":
     ensure             => $ensure,
     resource_type      => 'IPaddr2',
     resource_params    => "ip=${ip_address}${cidr_option}${nic_option}",


### PR DESCRIPTION
Effectively pcs refuses resource names containing colon character.

Since the IP address is used when creating pcmk_resource for IPaddr2 it breaks
the ip.pp manifests.

This patch replaces the colons with dots.

Tested on a 3 nodes cluster with ipv6 stack.