### PR TITLE
Resource constraint with colon in the name (IPv6)

### DIFF
--- a/lib/puppet/provider/pcmk_constraint/default.rb
+++ b/lib/puppet/provider/pcmk_constraint/default.rb
@@ -3,14 +3,18 @@ Puppet::Type.type(:pcmk_constraint).provide(:default) do
 
     ### overloaded methods
     def create
+        resource_resource = @resource[:resource].gsub(':', '.')
+        resource_name = @resource[:name].gsub(':', '.')
+        resource_location = @resource[:location].gsub(':', '.')
         case @resource[:constraint_type]
         when :location
-            cmd = 'constraint location add ' + @resource[:name] + ' '  + @resource[:resource] + ' ' + @resource[:location] + ' ' + @resource[:score]
+            cmd = 'constraint location add ' + resource_name + ' '  + resource_resource + ' ' + @resource[:location] + ' ' + @resource[:score]
         when :colocation
+            resource_location = @resource[:location].gsub(':', '.')
             if @resource[:master_slave]
-                cmd = 'constraint colocation add ' + @resource[:resource] + ' with master ' + @resource[:location] + ' ' + @resource[:score]
+              cmd = 'constraint colocation add ' + resource_resource + ' with master ' + resource_location + ' ' + @resource[:score]
             else 
-                cmd = 'constraint colocation add ' + @resource[:resource] + ' with ' + @resource[:location] + ' ' + @resource[:score]
+              cmd = 'constraint colocation add ' + resource_resource + ' with ' + resource_location + ' ' + @resource[:score]
             end
         else
             fail(String(@resource[:constraint_type]) + ' is an invalid location type')
@@ -21,30 +25,35 @@ Puppet::Type.type(:pcmk_constraint).provide(:default) do
     end
 
     def destroy
+        resource_resource = @resource[:resource].gsub(':', '.')
+        resource_name = @resource[:name].gsub(':', '.')
+        resource_location = @resource[:location].gsub(':', '.')
         case @resource[:constraint_type]
         when :location
-            cmd = 'constraint location remove ' + @resource[:name]
+            cmd = 'constraint location remove ' + resource_name
         when :colocation
-            cmd = 'constraint colocation remove ' + @resource[:resource] + ' ' + @resource[:location]
+            cmd = 'constraint colocation remove ' + resource_resource + ' ' + resource_location
         end
 
         pcs('constraint delete', cmd)
     end
 
     def exists?
+        resource_name = @resource[:name].gsub(':', '.')
+        resource_resource = @resource[:resource].gsub(':', '.')
+        resource_location = @resource[:location].gsub(':', '.')
         cmd = 'constraint ' + String(@resource[:constraint_type]) + ' show --full'
         pcs_out = pcs('show', cmd)
-
         # find the constraint
         for line in pcs_out.lines.each do
             case @resource[:constraint_type]
             when :location
-                return true if line.include? @resource[:name]
+                return true if line.include? resource_name
             when :colocation
                 if @resource[:master_slave]
-                  return true if line.include? @resource[:resource] + ' with ' + @resource[:location] and line.include? "with-rsc-role:Master" 
+                  return true if line.include? resource_resource + ' with ' + resource_location and line.include? "with-rsc-role:Master"
                 else
-                  return true if line.include? @resource[:resource] + ' with ' + @resource[:location] 
+                  return true if line.include? resource_resource + ' with ' + resource_location
                 end
             end
         end

--- a/manifests/constraint/base.pp
+++ b/manifests/constraint/base.pp
@@ -32,19 +32,23 @@ define pacemaker::constraint::base (
     $_constraint_params = ""
   }
 
+  $first_resource_cleaned  = regsubst($first_resource, '(:)', '.', 'G')
+  $second_resource_cleaned = regsubst($second_resource, '(:)', '.', 'G')
+
   if($ensure == absent) {
     if($constraint_type == 'location') {
+      $name_cleaned = regsubst($name, '(:)', '.', 'G')
       exec { "Removing location constraint ${name}":
-        command => "/usr/sbin/pcs constraint location remove ${name}",
-        onlyif  => "/usr/sbin/pcs constraint location show --full | grep ${name}",
+        command => "/usr/sbin/pcs constraint location remove ${name_cleaned}",
+        onlyif  => "/usr/sbin/pcs constraint location show --full | grep ${name_cleaned}",
         require => Exec["wait-for-settle"],
         tries     => $tries,
         try_sleep => $try_sleep,
       }
     } else {
       exec { "Removing ${constraint_type} constraint ${name}":
-        command => "/usr/sbin/pcs constraint ${constraint_type} remove ${first_resource} ${second_resource}",
-        onlyif  => "/usr/sbin/pcs constraint ${constraint_type} show | grep ${first_resource} | grep ${second_resource}",
+        command => "/usr/sbin/pcs constraint ${constraint_type} remove ${first_resource_cleaned} ${second_resource_cleaned}",
+        onlyif  => "/usr/sbin/pcs constraint ${constraint_type} show | grep ${first_resource_cleaned} | grep ${second_resource_cleaned}",
         require => Exec["wait-for-settle"],
         tries     => $tries,
         try_sleep => $try_sleep,
@@ -55,8 +59,8 @@ define pacemaker::constraint::base (
       'colocation': {
         fail("Deprecated use pacemaker::constraint::colocation")
         exec { "Creating colocation constraint ${name}":
-          command => "/usr/sbin/pcs constraint colocation add ${first_resource} ${second_resource} ${score}",
-          unless  => "/usr/sbin/pcs constraint colocation show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
+          command => "/usr/sbin/pcs constraint colocation add ${first_resource_cleaned} ${second_resource_cleaned} ${score}",
+          unless  => "/usr/sbin/pcs constraint colocation show | grep ${first_resource_cleaned} | grep ${second_resource_cleaned} > /dev/null 2>&1",
           require => [Exec["wait-for-settle"],Package["pcs"]],
           tries     => $tries,
           try_sleep => $try_sleep,
@@ -64,8 +68,8 @@ define pacemaker::constraint::base (
       }
       'order': {
         exec { "Creating order constraint ${name}":
-          command => "/usr/sbin/pcs constraint order ${first_action} ${first_resource} then ${second_action} ${second_resource} ${_constraint_params}",
-          unless  => "/usr/sbin/pcs constraint order show | grep ${first_resource} | grep ${second_resource} > /dev/null 2>&1",
+          command => "/usr/sbin/pcs constraint order ${first_action} ${first_resource_cleaned} then ${second_action} ${second_resource_cleaned} ${_constraint_params}",
+          unless  => "/usr/sbin/pcs constraint order show | grep ${first_resource_cleaned} | grep ${second_resource_cleaned} > /dev/null 2>&1",
           require => [Exec["wait-for-settle"],Package["pcs"]],
           tries     => $tries,
           try_sleep => $try_sleep,
@@ -74,8 +78,8 @@ define pacemaker::constraint::base (
       'location': {
         fail("Deprecated use pacemaker::constraint::location")
         exec { "Creating location constraint ${name}":
-          command => "/usr/sbin/pcs constraint location add ${name} ${first_resource} ${location} ${score}",
-          unless  => "/usr/sbin/pcs constraint location show | grep ${first_resource} > /dev/null 2>&1",
+          command => "/usr/sbin/pcs constraint location add ${name} ${first_resource_cleaned} ${location} ${score}",
+          unless  => "/usr/sbin/pcs constraint location show | grep ${first_resource_cleaned} > /dev/null 2>&1",
           require => [Exec["wait-for-settle"],Package["pcs"]],
           tries     => $tries,
           try_sleep => $try_sleep,


### PR DESCRIPTION
Related to the fix in[1], this add the possibility to add constraints to
resource whose name have a colon in it. IPv6 resource are a example of
when it's likely to happen.

Closes-Bug: rhbz#1298716

[1] https://github.com/redhat-openstack/puppet-pacemaker/commit/01c6000db5040055372021ad5a3231840ccb8bba