### PR TITLE
Initial pcs property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Finally, $resource_params are simply params that show up as options in
 the command immediately after the resource type without any additional
 keywords.
 
+#### Properties
+
+Properties can be set clusterwide or per-node using the pacemaker::property
+function. In the former case, when a property name is not recognized by
+pacemaker the force parameter needs to be true.
+
 #### See the pcs man page
 
 See the pcs man page for documentation for about the "pcs resource
@@ -190,7 +196,16 @@ $clone_params succeeds as expected.
       try_sleep       => 1,
     }
     # results in Debug: /usr/sbin/pcs resource create neutron-scale ocf:neutron:NeutronScale --clone globally-unique=true clone-max=3 interleave=true
-    
+
+    pacemaker::property { 'global-bar':
+      property  => 'bar',
+      value     => 'baz',
+      force     => true,
+      tries     => 1,
+      try_sleep => 1,
+    }
+    # results in Debug: /usr/sbin/pcs property set --force bar=baz
+
     pcmk_resource { "galera":
       resource_type   => "galera",
       resource_params => 'enable_creation=true wsrep_cluster_address="gcomm://pcmk-c1a1,pcmk-c1a2,pcmk-c1a3"',

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -1,0 +1,70 @@
+define pacemaker::property (
+  $property,
+  $value     = undef,
+  $node      = undef,
+  $force     = false,
+  $ensure    = present,
+  $tries     = 1,
+  $try_sleep = 10,
+) {
+  if $property == undef {
+    fail('Must provide property')
+  }
+  if ($ensure == 'present') and ! $value {
+    fail('When present, must provide value')
+  }
+
+  # Special-casing node branches due to https://bugzilla.redhat.com/show_bug.cgi?id=1302010
+  # (Basically pcs property show <property> will show all node properties anyway)
+  if $node {
+    if $ensure == absent {
+      exec { "Removing node-property ${property} on ${node}":
+        command   => "/usr/sbin/pcs property unset --node ${node} ${property}",
+        onlyif    => "/usr/sbin/pcs property show | grep ${property}= | grep ${node}",
+        require   => [Exec['wait-for-settle'],
+                      Class['::pacemaker::corosync']],
+        tries     => $tries,
+        try_sleep => $try_sleep,
+      }
+    } else {
+      if $force {
+        $cmd = "/usr/sbin/pcs property set --force --node ${node} ${property}=${value}"
+      } else {
+        $cmd = "/usr/sbin/pcs property set --node ${node} ${property}=${value}"
+      }
+      exec { "Creating node-property ${property} on ${node}":
+        command   => $cmd,
+        unless    => "/usr/sbin/pcs property show ${property} | grep \"${property}=${value}\" | grep ${node}",
+        require   => [Exec['wait-for-settle'],
+                      Class['::pacemaker::corosync']],
+        tries     => $tries,
+        try_sleep => $try_sleep,
+      }
+    }
+  } else {
+    if $ensure == absent {
+      exec { "Removing cluster-wide property ${property}":
+        command   => "/usr/sbin/pcs property unset ${property}",
+        onlyif    => "/usr/sbin/pcs property show | grep ${property}: ",
+        require   => [Exec['wait-for-settle'],
+                      Class['::pacemaker::corosync']],
+        tries     => $tries,
+        try_sleep => $try_sleep,
+      }
+    } else {
+      if $force {
+        $cmd = "/usr/sbin/pcs property set --force ${property}=${value}"
+      } else {
+        $cmd = "/usr/sbin/pcs property set ${property}=${value}"
+      }
+      exec { "Creating cluster-wide property ${property}":
+        command   => $cmd,
+        unless    => "/usr/sbin/pcs property show ${property} | grep \"${property}=${value}\"",
+        require   => [Exec['wait-for-settle'],
+                      Class['::pacemaker::corosync']],
+        tries     => $tries,
+        try_sleep => $try_sleep,
+      }
+    }
+  }
+}

--- a/manifests/stonith.pp
+++ b/manifests/stonith.pp
@@ -1,19 +1,13 @@
 class pacemaker::stonith ($disable=true) {
   if $disable == true {
-    exec {"Disable STONITH":
-        command => "/usr/sbin/pcs property set stonith-enabled=false",
-        unless => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
-        require => [ Exec["wait-for-settle"],
-                     Class['::pacemaker::corosync']
-                   ],
+    pacemaker::property { 'Disable STONITH':
+        property => 'stonith-enabled',
+        value    => false,
     }
   } else {
-    exec {"Enable STONITH":
-        command => "/usr/sbin/pcs property set stonith-enabled=true",
-        onlyif => "/usr/sbin/pcs property show stonith-enabled | grep 'stonith-enabled: false'",
-        require => [ Exec["wait-for-settle"],
-                     Class['::pacemaker::corosync']
-                   ],
+    pacemaker::property { 'Enable STONITH':
+        property => 'stonith-enabled',
+        value    => true,
     }
   }
 }

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -115,3 +115,20 @@ pacemaker::constraint::base { "ip-192.168.122.223_on_192.168.122.3":
   location        => '192.168.122.3',
   score           => 'INFINITY',
 }
+
+### Add properties
+pacemaker::property { 'global-bar':
+  property   => 'bar',
+  value      => 'baz',
+  force      => true,
+  tries      => 1,
+  try_sleep  => 1,
+}
+
+pacemaker::property { 'node-foo':
+  property   => 'foo',
+  value      => 'baz',
+  node       => 'cluster1',
+  tries      => 1,
+  try_sleep  => 1,
+}


### PR DESCRIPTION
Add a function in order to support pcs properties natively.
Support is per cluster-wide properties or per-node properties.
Example:

pacemaker::property {"global-bar":
  property        => "bar",
  value           => "baz",
  force           => true,
  tries           => 1,
  try_sleep       => 1,
}