### PR TITLE
Add initial support for 'location rule' type of constraints

### DIFF
--- a/lib/puppet/type/pcmk_constraint.rb
+++ b/lib/puppet/type/pcmk_constraint.rb
@@ -9,7 +9,7 @@ Puppet::Type.newtype(:pcmk_constraint) do
 
     newparam(:constraint_type) do
         desc "the pacemaker type to create"
-        newvalues(:location, :colocation)
+        newvalues(:location, :colocation, :location_rule)
     end
     newparam(:resource) do
         desc "resource list"
@@ -22,10 +22,17 @@ Puppet::Type.newtype(:pcmk_constraint) do
     newparam(:score) do
         desc "Score"
     end
+    newparam(:expression) do
+        desc "Expression"
+    end
+    newparam(:resource_discovery) do
+        desc "Resource Discovery"
+    end
     newparam(:master_slave) do
         desc "Enable master/slave support with multistage"
         newvalues(:true)
         newvalues(:false)
     end
+
 
 end

--- a/manifests/constraint/location_rule.pp
+++ b/manifests/constraint/location_rule.pp
@@ -1,0 +1,15 @@
+define pacemaker::constraint::location_rule ($resource,
+                                             $expression,
+                                             $score,
+                                             $resource_discovery='always',
+                                             $ensure='present') {
+    pcmk_constraint {"location-$resource-rule":
+       constraint_type    => location_rule,
+       resource           => $resource,
+       expression         => $expression,
+       score              => $score,
+       resource_discovery => $resource_discovery,
+       ensure             => $ensure,
+       require => Exec["wait-for-settle"],
+   }
+}

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -115,3 +115,10 @@ pacemaker::constraint::base { "ip-192.168.122.223_on_192.168.122.3":
   location        => '192.168.122.3',
   score           => 'INFINITY',
 }
+
+pacemaker::constraint::location_rule { "ip-192.168.122.223_expr":
+  resource           => 'ip-192.168.122.223',
+  expression         => 'role eq webserver',
+  resource_discovery => 'exclusive',
+  score              => 0,
+}


### PR DESCRIPTION
pcs supports location constraints that add rules about where a resource
is allowed to run or not run.

Support for the following types is added via a new 'location_rule'
type of constraint:

    pcs constraint location haproxy-clone rule resource-discovery=exclusive \
        score=0 osprole eq controller

Note: I chose to add location_rule constraint as the location rule semantics
did not fit very well with the existing constraints. I am open to suggestions
for different approaches.