### PR TITLE
Fix invalid boolean check for properties' values

### DIFF
--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -10,7 +10,7 @@ define pacemaker::property (
   if $property == undef {
     fail('Must provide property')
   }
-  if ($ensure == 'present') and ! $value {
+  if ($ensure == 'present') and $value == undef {
     fail('When present, must provide value')
   }
 


### PR DESCRIPTION
The property resource checks that if 'ensure' is set to present, then a
value must be set; This check is wrong because false can actually be a
valid value for the property. In reality, what we want to check for is
if the value has been set at all. So this change introduces a check for
undef.